### PR TITLE
Add in all the environment variables the containers need for runtime

### DIFF
--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -19,3 +19,29 @@ spec:
           image: ${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}
           ports:
             - containerPort: 8080
+          # initial poc environment variables while auth functionality is not active
+          env:
+          - name: PRODUCT_ID
+            value: UNASSIGNED
+          - name: REDIS_ENABLED
+            value: false
+          - name: REDIS_HOST
+            value: unused
+          - name: HMPPS_AUTH_URL
+            value: "http://unused:8080/auth"
+          - name: AUTH_CODE_CLIENT_ID
+            value: unused
+          - name: AUTH_CODE_CLIENT_SECRET
+            value: unused
+          - name: CLIENT_CREDS_CLIENT_ID
+            value: unused
+          - name: CLIENT_CREDS_CLIENT_SECRET
+            value: unused
+          - name: SESSION_SECRET
+            value: unused
+          - name: TOKEN_VERIFICATION_API_URL
+            value: "http://unused:8080/auth"
+          - name: TOKEN_VERIFICATION_ENABLED
+            value: false
+          - name: INGRESS_URL
+            value: "https://stg-manage-community-sentence-ui-dev.apps.live.cloud-platform.service.justice.gov.uk"


### PR DESCRIPTION
This method if for the first drop. 
There are no secrets so these can be hardcoded in the code and deployment for the first release.
Future iterations will add config maps and secrets appropriately when we actually need to use all the functionality - hopefully by then we will have registered the service and can use the helm deploy.