### PR TITLE
Switch to using config map for environment variables and ensure that all values are strings for compatibility

### DIFF
--- a/.github/workflows/simple_deploy.yml
+++ b/.github/workflows/simple_deploy.yml
@@ -27,6 +27,7 @@ jobs:
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
       - run: |
+          cat deployments/templates/configmap.yml | envsubst > deployments/configmap.yml
           cat deployments/templates/deployment.yml | envsubst > deployments/deployment.yml
           cat deployments/templates/ingress.yml | envsubst > deployments/ingress.yml
           cat deployments/templates/service.yml | envsubst > deployments/service.yml

--- a/deployments/templates/configmap.yml
+++ b/deployments/templates/configmap.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ui-config
+data:
+  PRODUCT_ID: "UNASSIGNED"
+  REDIS_ENABLED: "false"
+  REDIS_HOST: "unused"
+  HMPPS_AUTH_URL: "http://unused:8080/auth"
+  AUTH_CODE_CLIENT_ID: "unused"
+  AUTH_CODE_CLIENT_SECRET: "unused"
+  CLIENT_CREDS_CLIENT_ID: "unused"
+  CLIENT_CREDS_CLIENT_SECRET: "unused"
+  SESSION_SECRET: "unused"
+  TOKEN_VERIFICATION_API_URL: "http://unused:8080/auth"
+  TOKEN_VERIFICATION_ENABLED: "false"
+  INGRESS_URL: "https://stg-manage-community-sentence-ui-dev.apps.live.cloud-platform.service.justice.gov.uk"

--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: stg-manage-community-sentence-ui
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: stg-manage-community-sentence-ui # this should match the selector in service.yml
@@ -20,28 +20,6 @@ spec:
           ports:
             - containerPort: 8080
           # initial poc environment variables while auth functionality is not active
-          env:
-          - name: PRODUCT_ID
-            value: UNASSIGNED
-          - name: REDIS_ENABLED
-            value: false
-          - name: REDIS_HOST
-            value: unused
-          - name: HMPPS_AUTH_URL
-            value: "http://unused:8080/auth"
-          - name: AUTH_CODE_CLIENT_ID
-            value: unused
-          - name: AUTH_CODE_CLIENT_SECRET
-            value: unused
-          - name: CLIENT_CREDS_CLIENT_ID
-            value: unused
-          - name: CLIENT_CREDS_CLIENT_SECRET
-            value: unused
-          - name: SESSION_SECRET
-            value: unused
-          - name: TOKEN_VERIFICATION_API_URL
-            value: "http://unused:8080/auth"
-          - name: TOKEN_VERIFICATION_ENABLED
-            value: false
-          - name: INGRESS_URL
-            value: "https://stg-manage-community-sentence-ui-dev.apps.live.cloud-platform.service.justice.gov.uk"
+          envFrom:
+            - configMapRef:
+              name: ui-config


### PR DESCRIPTION
previous deployment failed due to non-string value incompatibility