### PR TITLE
Add notification alerts to pop landing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.744.0",
-        "@ministryofjustice/frontend": "^3.3.1",
+        "@ministryofjustice/frontend": "^3.7.0",
         "@ministryofjustice/hmpps-monitoring": "^0.0.1-beta.2",
         "@types/cookie-parser": "^1.4.8",
         "agentkeepalive": "^4.6.0",
@@ -2775,19 +2775,17 @@
       }
     },
     "node_modules/@ministryofjustice/frontend": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-3.3.1.tgz",
-      "integrity": "sha512-4npwkub8xkhp+YFUK9MIm8armTTs7hzkvT33Ijetxi6aI4Ezzym7XPv4XjQavYAewmv+CHv6WqbBCqtJrWwtmg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-3.7.0.tgz",
+      "integrity": "sha512-o84Sqy+1jqc1vaxIZfyG4VwJzdpDUK88O9COJFVLcFmW+Np80onlFlGAVjDUxNHYvtBdJx40w1dayq53wmtxgQ==",
       "license": "MIT",
-      "dependencies": {
-        "govuk-frontend": "^5.0.0",
-        "moment": "^2.27.0"
-      },
       "engines": {
         "node": ">= 4.2.0"
       },
       "peerDependencies": {
-        "jquery": "^3.6.0"
+        "govuk-frontend": "5.x",
+        "jquery": "3.x",
+        "moment": "2.x"
       }
     },
     "node_modules/@ministryofjustice/hmpps-monitoring": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.744.0",
-    "@ministryofjustice/frontend": "^3.3.1",
+    "@ministryofjustice/frontend": "^3.7.0",
     "@ministryofjustice/hmpps-monitoring": "^0.0.1-beta.2",
     "@types/cookie-parser": "^1.4.8",
     "agentkeepalive": "^4.6.0",

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -12,7 +12,12 @@ export default function routes(): Router {
     res.render('pages/index')
   })
   get('/pop', async (req, res, next) => {
-    res.render('pages/pop/index')
+    // /pop?scenario=missed
+    // /pop?scenario=reminder
+
+    const { scenario } = req.query
+
+    res.render('pages/pop/index', { scenario })
   })
 
   get('/your-details', async (req, res, next) => {

--- a/server/views/pages/pop/index.njk
+++ b/server/views/pages/pop/index.njk
@@ -1,3 +1,5 @@
+{%- from "moj/components/alert/macro.njk" import mojAlert -%}
+
 {% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - Home" %}
@@ -5,8 +7,28 @@
 
 {% block content %}
 
-<h1 class="govuk-heading-l">Welcome, Carolina</h1> 
+<h1 class="govuk-heading-l">Welcome, Carolina</h1>
 <p class="govuk-body">View and manage your community payback</p>
+
+{% if scenario == "missed" %}
+{{ mojAlert({
+  variant: "error",
+  title: "Missed appointment",
+  showTitleAsHeading: true,
+  dismissible: false,
+  text: 'You failed to attend your scheduled probation appointment on 3 March 2025, breaching your supervision requirements. Please <a href="#">contact</a> your probation practitioner as soon as possible to discuss this matter.'
+}) }}
+{% endif %}
+
+{% if scenario == "reminder" %}
+{{ mojAlert({
+  variant: "information",
+  title: "Appointment reminder",
+  showTitleAsHeading: true,
+  dismissible: false,
+  html: 'You have an appointment booked for 20 March 2025 at 2pm. <a href="#">View your appointment</a> if you need to reschedule it.'
+}) }}
+{% endif %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/server/views/pages/pop/index.njk
+++ b/server/views/pages/pop/index.njk
@@ -16,7 +16,7 @@
   title: "Missed appointment",
   showTitleAsHeading: true,
   dismissible: false,
-  text: 'You failed to attend your scheduled probation appointment on 3 March 2025, breaching your supervision requirements. Please <a href="#">contact</a> your probation practitioner as soon as possible to discuss this matter.'
+  html: 'You failed to attend your scheduled probation appointment on 3 March 2025. You have 48 hours to <a href="#">respond to this notice</a> and explain why you missed this. If you fail to do that, this might count as a breach of your conditions.'
 }) }}
 {% endif %}
 


### PR DESCRIPTION
Three scenarios here:

No notifications: /pop
Missed appointment: /pop?scenario=missed
Appointment reminder: /pop?scenario=reminder

Links are deadlinks until view appointments and messaging functionality are available.