### PR TITLE
Fix back link url to include pop section prefix

### DIFF
--- a/server/views/pages/pop/upwConditions.njk
+++ b/server/views/pages/pop/upwConditions.njk
@@ -9,7 +9,7 @@
   <div class="govuk-grid-column-full">
      {{ govukBackLink({
       text: "Back",
-      href: "/conditions"
+      href: "/pop/conditions"
     }) }}
   </div>
 </div>


### PR DESCRIPTION


## What changed and Why?

Fixed the back link to avoid a 404 as it was missing the /pop/ prefix

## Checklist

Before you ask people to review this PR:

- [x] **Tests and linting** are passing.
- [x] **Branch is up to date** with merge target (`main` or `next`) (no merge conflicts).
- [x] **No unnecessary whitespace changes** (avoid unnecessary diffs).
- [x] **PR description clearly explains** what changed and why, with a Trello link.
- [x] **Diff has been checked** for any unexpected changes.
- [x] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.
