### PR TITLE
Disable next environment deployment configuration

### DIFF
--- a/.github/workflows/simple_deploy_next.yml
+++ b/.github/workflows/simple_deploy_next.yml
@@ -1,9 +1,12 @@
 name: Next Cloud Platform Deploy
-
+# This assumes a namespace with environment name 'next' which shares the ECR of the dev environment
+# and has stored the namespace and kubernetes token in suffixed environment variables
+# See this commit for namespace details: https://github.com/ministryofjustice/cloud-platform-environments/commit/764a13559d37da4d8186c36420adcde13ee8c780
+# Namespace has now been decommissioned after the initial research stages - left in for documentation purposes
 on:
-  push:
-    branches: [next]
-  workflow_dispatch:
+  # push:
+  #   branches: [next]
+  workflow_dispatch: # disabled manually
 
 jobs:
   ecr:


### PR DESCRIPTION
[Trello link](https://trello.com/c/Na7UD3rF/341-decommission-next-namespace)

## What changed and Why?

The deployment configuration needs to be disabled before we decommission the namespace in full.

## Checklist

Before you ask people to review this PR:

- [x] **Tests and linting** are passing.
- [x] **Branch is up to date** with merge target (`main` or `next`) (no merge conflicts).
- [x] **No unnecessary whitespace changes** (avoid unnecessary diffs).
- [x] **PR description clearly explains** what changed and why, with a Trello link.
- [x] **Diff has been checked** for any unexpected changes.
- [x] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.
